### PR TITLE
Per-unit communication protocol

### DIFF
--- a/src/communication/channels/closed.comm-channel.ts
+++ b/src/communication/channels/closed.comm-channel.ts
@@ -35,7 +35,7 @@ export class ClosedCommChannel implements CommChannel {
     return new Supply(noop).off(this.#reason);
   }
 
-  signal<TSignal extends CommPacket>(name: string, _signal: TSignal): void {
+  signal<TSignal extends CommPacket>(name: string, _signal: TSignal): never {
     throw new CommError(
         this.to,
         `Can not send signal "${name}" to ${this.#to} over closed channel`,

--- a/src/communication/channels/direct.comm-channel.spec.ts
+++ b/src/communication/channels/direct.comm-channel.spec.ts
@@ -54,7 +54,7 @@ describe('DirectCommChannel', () => {
       const signal: TestPacket = { payload: 'test' };
 
       channel.signal('ping', signal);
-      expect(receiver.receive).toHaveBeenCalledWith(signal, channel);
+      expect(receiver.receive).toHaveBeenCalledWith(signal);
     });
     it('processes signal with command processor', () => {
 
@@ -68,7 +68,7 @@ describe('DirectCommChannel', () => {
       const signal: TestPacket = { payload: 'test' };
 
       channel.signal('ping', signal);
-      expect(handler.receive).toHaveBeenCalledWith(signal, channel);
+      expect(handler.receive).toHaveBeenCalledWith(signal);
     });
     it('processes signal with fallback handler', () => {
 
@@ -86,8 +86,8 @@ describe('DirectCommChannel', () => {
       const signal: TestPacket = { payload: 'test' };
 
       channel.signal('ping', signal);
-      expect(receiver1.receive).toHaveBeenCalledWith(signal, channel);
-      expect(receiver2.receive).toHaveBeenCalledWith(signal, channel);
+      expect(receiver1.receive).toHaveBeenCalledWith(signal);
+      expect(receiver2.receive).toHaveBeenCalledWith(signal);
     });
     it('processes signal with fallback processor', () => {
 
@@ -105,8 +105,8 @@ describe('DirectCommChannel', () => {
       const signal: TestPacket = { payload: 'test' };
 
       channel.signal('ping', signal);
-      expect(receiver1.receive).toHaveBeenCalledWith(signal, channel);
-      expect(receiver2.receive).toHaveBeenCalledWith(signal, channel);
+      expect(receiver1.receive).toHaveBeenCalledWith(signal);
+      expect(receiver2.receive).toHaveBeenCalledWith(signal);
     });
     it('does not send signal when channel closed', () => {
 

--- a/src/communication/channels/direct.comm-channel.spec.ts
+++ b/src/communication/channels/direct.comm-channel.spec.ts
@@ -6,7 +6,7 @@ import { Unit } from '../../unit';
 import { CommError } from '../comm-error';
 import { CommReceiver, CommResponder } from '../comm-handler';
 import { CommPacket } from '../comm-packet';
-import { CommProcessor } from '../comm-processor';
+import { CommProcessor, commProcessorBy } from '../comm-processor';
 import { HandlerCommProcessor, ProxyCommProcessor } from '../handlers';
 import { DirectCommChannel } from './direct.comm-channel';
 
@@ -49,7 +49,7 @@ describe('DirectCommChannel', () => {
         receive: jest.fn(() => true),
       };
 
-      processor = new HandlerCommProcessor(receiver);
+      processor = commProcessorBy(receiver);
 
       const signal: TestPacket = { payload: 'test' };
 
@@ -130,7 +130,7 @@ describe('DirectCommChannel', () => {
         respond: jest.fn(request => onPromise({ ...request, payload: { re: request.payload } })),
       };
 
-      processor = new HandlerCommProcessor(responder);
+      processor = commProcessorBy(responder);
 
       expect(await channel.request<TestPacket, TestPacket>('ping', { payload: 'test' }))
           .toEqual({ payload: { re: 'test' } });

--- a/src/communication/channels/direct.comm-channel.ts
+++ b/src/communication/channels/direct.comm-channel.ts
@@ -4,6 +4,7 @@ import { Unit } from '../../unit';
 import { CommChannel } from '../comm-channel';
 import { CommPacket } from '../comm-packet';
 import { CommProcessor } from '../comm-processor';
+import { FinalCommProcessor } from '../handlers';
 import { ClosedCommChannel } from './closed.comm-channel';
 
 /**
@@ -37,14 +38,14 @@ export class DirectCommChannel implements CommChannel {
   ) {
     this.#to = to;
     this.#supply = supply;
-    this.#processor = processor;
+    this.#processor = new FinalCommProcessor(processor);
     this.supply.whenOff(reason => {
 
       const closed = new ClosedCommChannel(this.to, reason);
 
       this.#processor = {
         receive(name, signal, _channel) {
-          closed.signal(name, signal);
+          return closed.signal(name, signal);
         },
         respond(name, request, _channel) {
           return closed.request(name, request);

--- a/src/communication/channels/direct.comm-channel.ts
+++ b/src/communication/channels/direct.comm-channel.ts
@@ -44,10 +44,10 @@ export class DirectCommChannel implements CommChannel {
       const closed = new ClosedCommChannel(this.to, reason);
 
       this.#processor = {
-        receive(name, signal, _channel) {
+        receive(name, signal) {
           return closed.signal(name, signal);
         },
-        respond(name, request, _channel) {
+        respond(name, request) {
           return closed.request(name, request);
         },
       };
@@ -63,12 +63,12 @@ export class DirectCommChannel implements CommChannel {
   }
 
   signal<TSignal extends CommPacket>(name: string, signal: TSignal): void {
-    this.#processor.receive(name, signal, this);
+    this.#processor.receive(name, signal);
   }
 
   request<TRequest extends CommPacket, TResponse = CommPacket>(name: string, request: TRequest): OnEvent<[TResponse]> {
 
-    const onResponse = this.#processor.respond(name, request, this) as OnEvent<[TResponse]>;
+    const onResponse = this.#processor.respond(name, request) as OnEvent<[TResponse]>;
 
     return this.supply.isOff
         ? onResponse

--- a/src/communication/channels/message.comm-channel.spec.ts
+++ b/src/communication/channels/message.comm-channel.spec.ts
@@ -89,7 +89,7 @@ describe('MessageCommChannel', () => {
       const resolver = newPromiseResolver();
       const receiver: CommReceiver<TestPacket> = {
         name: 'ping',
-        receive: jest.fn(() => resolver.resolve()),
+        receive: jest.fn(() => { resolver.resolve(); return true; }),
       };
 
       remoteProcessor = new HandlerCommProcessor(receiver);
@@ -104,7 +104,7 @@ describe('MessageCommChannel', () => {
       const resolver = newPromiseResolver();
       const receiver: CommReceiver<TestPacket> = {
         name: 'ping',
-        receive: jest.fn(() => resolver.resolve()),
+        receive: jest.fn(() => { resolver.resolve(); return true; }),
       };
 
       remoteProcessor = new HandlerCommProcessor(receiver);
@@ -232,7 +232,7 @@ describe('MessageCommChannel', () => {
 
       const handler: CommReceiver = {
         name: 'test',
-        receive: () => resolver.resolve(),
+        receive: () => { resolver.resolve(); return true; },
       };
 
       remoteProcessor = new HandlerCommProcessor(handler);

--- a/src/communication/channels/message.comm-channel.spec.ts
+++ b/src/communication/channels/message.comm-channel.spec.ts
@@ -97,7 +97,7 @@ describe('MessageCommChannel', () => {
       channel.signal<TestPacket>('ping', { payload: 'test' });
       await resolver.promise();
 
-      expect(receiver.receive).toHaveBeenCalledWith(expect.objectContaining({ payload: 'test' }), remoteChannel);
+      expect(receiver.receive).toHaveBeenCalledWith(expect.objectContaining({ payload: 'test' }));
     });
     it('transfers objects', async () => {
 
@@ -114,7 +114,7 @@ describe('MessageCommChannel', () => {
       channel.signal<TestPacket>('ping', { meta: { transferList: [payload] }, payload });
       await resolver.promise();
 
-      expect(receiver.receive).toHaveBeenCalledWith({ meta: {}, payload }, remoteChannel);
+      expect(receiver.receive).toHaveBeenCalledWith({ meta: {}, payload });
     });
   });
 

--- a/src/communication/channels/message.comm-channel.spec.ts
+++ b/src/communication/channels/message.comm-channel.spec.ts
@@ -7,7 +7,7 @@ import { SpyInstance, spyOn } from 'jest-mock';
 import { MessageChannel, MessagePort } from 'worker_threads';
 import { OrderTest } from '../../testing';
 import { Unit } from '../../unit';
-import { CommHandler, CommReceiver, CommResponder } from '../comm-handler';
+import { CommReceiver, CommResponder } from '../comm-handler';
 import { CommPacket } from '../comm-packet';
 import { CommProcessor } from '../comm-processor';
 import { HandlerCommProcessor, ProxyCommProcessor } from '../handlers';
@@ -87,34 +87,34 @@ describe('MessageCommChannel', () => {
     it('sends signal', async () => {
 
       const resolver = newPromiseResolver();
-      const handler: CommHandler<TestPacket, void> = {
+      const receiver: CommReceiver<TestPacket> = {
         name: 'ping',
         receive: jest.fn(() => resolver.resolve()),
       };
 
-      remoteProcessor = new HandlerCommProcessor(handler);
+      remoteProcessor = new HandlerCommProcessor(receiver);
 
       channel.signal<TestPacket>('ping', { payload: 'test' });
       await resolver.promise();
 
-      expect(handler.receive).toHaveBeenCalledWith(expect.objectContaining({ payload: 'test' }), remoteChannel);
+      expect(receiver.receive).toHaveBeenCalledWith(expect.objectContaining({ payload: 'test' }), remoteChannel);
     });
     it('transfers objects', async () => {
 
       const resolver = newPromiseResolver();
-      const handler: CommHandler<TestPacket, void> = {
+      const receiver: CommReceiver<TestPacket> = {
         name: 'ping',
         receive: jest.fn(() => resolver.resolve()),
       };
 
-      remoteProcessor = new HandlerCommProcessor(handler);
+      remoteProcessor = new HandlerCommProcessor(receiver);
 
       const payload = new Int8Array([1, 2, 3, 99]).buffer;
 
       channel.signal<TestPacket>('ping', { meta: { transferList: [payload] }, payload });
       await resolver.promise();
 
-      expect(handler.receive).toHaveBeenCalledWith({ meta: {}, payload }, remoteChannel);
+      expect(receiver.receive).toHaveBeenCalledWith({ meta: {}, payload }, remoteChannel);
     });
   });
 

--- a/src/communication/channels/message.comm-channel.ts
+++ b/src/communication/channels/message.comm-channel.ts
@@ -7,7 +7,7 @@ import { Unit } from '../../unit';
 import { CommChannel } from '../comm-channel';
 import { CommPacket } from '../comm-packet';
 import { CommProcessor } from '../comm-processor';
-import { HandlerCommProcessor } from '../handlers';
+import { FinalCommProcessor, HandlerCommProcessor } from '../handlers';
 
 const enum MessageComm$Type {
   Signal,
@@ -26,7 +26,7 @@ export class MessageCommChannel implements CommChannel {
   readonly #to: Unit;
   readonly #supply: Supply;
   readonly #port: MessagePort;
-  readonly #processor: CommProcessor;
+  readonly #processor: FinalCommProcessor;
   readonly #logger: Logger;
   readonly #streams = new Map<string, EventEmitter<[CommPacket]>>();
 
@@ -59,7 +59,7 @@ export class MessageCommChannel implements CommChannel {
       this.supply.off();
     });
     this.#port = port;
-    this.#processor = processor;
+    this.#processor = new FinalCommProcessor(processor);
     this.#logger = logger;
     port.on('message', (wrapper: MessageComm$Wrapper) => this.#onCommand(wrapper));
   }
@@ -152,7 +152,7 @@ export class MessageCommChannel implements CommChannel {
     this.#port.postMessage(endRequestWrapper);
   }
 
-  #onCommand(wrapper: MessageComm$Wrapper): void {
+  #onCommand(wrapper: MessageComm$Wrapper): void | boolean {
 
     const { sqdn } = wrapper;
 

--- a/src/communication/channels/message.comm-channel.ts
+++ b/src/communication/channels/message.comm-channel.ts
@@ -163,7 +163,7 @@ export class MessageCommChannel implements CommChannel {
       if (typeof body === 'object' && body) {
         switch (type) {
         case MessageComm$Type.Signal:
-          return this.#processor.receive(name, body, this);
+          return this.#processor.receive(name, body);
         case MessageComm$Type.Request:
           return this.#onRequest(name, body);
         case MessageComm$Type.Response:
@@ -187,7 +187,7 @@ export class MessageCommChannel implements CommChannel {
     }
 
     const stream = this.#openStream(streamId);
-    const onResponse = this.#processor.respond(name, request, this);
+    const onResponse = this.#processor.respond(name, request);
 
     onResponse({
       supply: stream.supply.derive().whenOff(reason => this.#closeStream(name, streamId, reason)),

--- a/src/communication/channels/proxy.comm-channel.spec.ts
+++ b/src/communication/channels/proxy.comm-channel.spec.ts
@@ -75,7 +75,7 @@ describe('ProxyCommChannel', () => {
         processor = new HandlerCommProcessor(handler);
 
         channel.signal<TestPacket>('test', signal);
-        expect(handler.receive).toHaveBeenCalledWith(signal, target);
+        expect(handler.receive).toHaveBeenCalledWith(signal);
       });
     });
 
@@ -163,7 +163,7 @@ describe('ProxyCommChannel', () => {
         const target = new DirectCommChannel({ to: unit, processor: new HandlerCommProcessor(handler) });
 
         targets.send(target);
-        expect(handler.receive).toHaveBeenCalledWith(signal, target);
+        expect(handler.receive).toHaveBeenCalledWith(signal);
       });
       it('warns when buffered signal can not be sent', () => {
         channel.signal('test', {});
@@ -347,8 +347,8 @@ describe('ProxyCommChannel', () => {
         const target2 = new DirectCommChannel({ to: unit, processor });
 
         targets.send(target2);
-        expect(handler.receive).toHaveBeenCalledWith(signal1, target2);
-        expect(handler.receive).toHaveBeenCalledWith(signal2, target2);
+        expect(handler.receive).toHaveBeenCalledWith(signal1);
+        expect(handler.receive).toHaveBeenCalledWith(signal2);
         expect(handler.receive).toHaveBeenCalledTimes(2);
       });
       it('starts buffering when `undefined` target received', () => {
@@ -363,8 +363,8 @@ describe('ProxyCommChannel', () => {
         const target2 = new DirectCommChannel({ to: unit, processor });
 
         targets.send(target2);
-        expect(handler.receive).toHaveBeenCalledWith(signal1, target2);
-        expect(handler.receive).toHaveBeenCalledWith(signal2, target2);
+        expect(handler.receive).toHaveBeenCalledWith(signal1);
+        expect(handler.receive).toHaveBeenCalledWith(signal2);
         expect(handler.receive).toHaveBeenCalledTimes(2);
       });
       it('handles closing target while draining buffer', () => {
@@ -391,7 +391,7 @@ describe('ProxyCommChannel', () => {
         const target2 = new DirectCommChannel({ to: unit, processor });
 
         targets.send(target2);
-        expect(handler.receive).toHaveBeenCalledWith(signal2, target2);
+        expect(handler.receive).toHaveBeenCalledWith(signal2);
         expect(handler.receive).toHaveBeenCalledTimes(1);
       });
     });

--- a/src/communication/channels/proxy.comm-channel.spec.ts
+++ b/src/communication/channels/proxy.comm-channel.spec.ts
@@ -66,7 +66,7 @@ describe('ProxyCommChannel', () => {
 
         const handler: CommReceiver<TestPacket> = {
           name: 'test',
-          receive: jest.fn(),
+          receive: jest.fn(() => true),
         };
         const signal: TestPacket = {
           payload: 'test payload',
@@ -376,6 +376,7 @@ describe('ProxyCommChannel', () => {
           name: 'test',
           receive() {
             supply1.off();
+            return true;
           },
         };
         const target1 = new DirectCommChannel({

--- a/src/communication/comm-handler.ts
+++ b/src/communication/comm-handler.ts
@@ -7,15 +7,11 @@ import { CommPacket } from './comm-packet';
  *
  * Either a signal receiver, or a request responder.
  *
- * A {@link Communicator} processes incoming commands by available handlers. Available handlers provided in unit context
- * available via {@link CommProcessor}.
- *
- * @typeParam TIn - Input packet type.
- * @typeParam TOut - Output packet type.
+ * A {@link Communicator} processes incoming commands by handlers available in unit context as {@link CommProcessor}.
  */
-export type CommHandler<TIn extends CommPacket = CommPacket, TOut extends CommPacket | void = CommPacket> =
-    | CommReceiver<TIn>
-    | (TOut extends CommPacket ? CommResponder<TIn, TOut> : never);
+export type CommHandler =
+    | CommReceiver
+    | CommResponder;
 
 /**
  * Inbound {@link CommChannel.signal signal} receiver.

--- a/src/communication/comm-handler.ts
+++ b/src/communication/comm-handler.ts
@@ -1,6 +1,7 @@
 import { OnEvent } from '@proc7ts/fun-events';
 import { CommPacket } from './comm-packet';
 import { CommProcessor } from './comm-processor';
+import { CommProtocol } from './comm-protocol';
 
 /**
  * Inbound command handler.
@@ -9,14 +10,16 @@ import { CommProcessor } from './comm-processor';
  *
  * - signal {@link CommReceiver receiver},
  * - request {@link CommResponder responder},
- * - or command {@link CommProcessor processor}.
+ * - command {@link CommProcessor processor}, or
+ * - communication {@link CommProtocol protocol}.
  *
- * A {@link Communicator} processes incoming commands by handlers available in unit context as {@link CommProcessor}.
+ * A {@link Communicator} processes incoming commands by handlers available in unit context as {@link CommProtocol}.
  */
 export type CommHandler =
     | CommReceiver
     | CommResponder
-    | CommProcessor;
+    | CommProcessor
+    | CommProtocol;
 
 /**
  * Inbound {@link CommChannel.signal signal} receiver.

--- a/src/communication/comm-handler.ts
+++ b/src/communication/comm-handler.ts
@@ -1,20 +1,23 @@
 import { OnEvent } from '@proc7ts/fun-events';
 import { CommChannel } from './comm-channel';
 import { CommPacket } from './comm-packet';
+import { CommProcessor } from './comm-processor';
 
 /**
  * Inbound command handler.
  *
  * One of:
  *
- * - signal {@link CommReceiver receiver}, or
- * - request {@link CommResponder responder}.
+ * - signal {@link CommReceiver receiver},
+ * - request {@link CommResponder responder},
+ * - or command {@link CommProcessor processor}.
  *
  * A {@link Communicator} processes incoming commands by handlers available in unit context as {@link CommProcessor}.
  */
 export type CommHandler =
     | CommReceiver
-    | CommResponder;
+    | CommResponder
+    | CommProcessor;
 
 /**
  * Inbound {@link CommChannel.signal signal} receiver.

--- a/src/communication/comm-handler.ts
+++ b/src/communication/comm-handler.ts
@@ -1,5 +1,4 @@
 import { OnEvent } from '@proc7ts/fun-events';
-import { CommChannel } from './comm-channel';
 import { CommPacket } from './comm-packet';
 import { CommProcessor } from './comm-processor';
 
@@ -38,11 +37,10 @@ export interface CommReceiver<TSignal extends CommPacket = CommPacket> {
    * will receive the signal then.
    *
    * @param signal - Received signal data packet.
-   * @param channel - Communication channel the signal received from.
    *
    * @returns Either `true` if the signal processed, or `false` otherwise.
    */
-  receive(signal: TSignal, channel: CommChannel): boolean;
+  receive(signal: TSignal): boolean;
 
 }
 
@@ -66,10 +64,9 @@ export interface CommResponder<TRequest extends CommPacket = CommPacket, TRespon
    * responder in processing chain will receive the request then.
    *
    * @param request - Received request data packet.
-   * @param channel - Communication channel the request received from.
    *
    * @returns Either `OnEvent` sender of response data packets, or falsy value if the request can not be responded.
    */
-  respond(request: TRequest, channel: CommChannel): OnEvent<[TResponse]> | false | null | undefined;
+  respond(request: TRequest): OnEvent<[TResponse]> | false | null | undefined;
 
 }

--- a/src/communication/comm-handler.ts
+++ b/src/communication/comm-handler.ts
@@ -5,7 +5,10 @@ import { CommPacket } from './comm-packet';
 /**
  * Inbound command handler.
  *
- * Either a signal receiver, or a request responder.
+ * One of:
+ *
+ * - signal {@link CommReceiver receiver}, or
+ * - request {@link CommResponder responder}.
  *
  * A {@link Communicator} processes incoming commands by handlers available in unit context as {@link CommProcessor}.
  */
@@ -28,10 +31,15 @@ export interface CommReceiver<TSignal extends CommPacket = CommPacket> {
   /**
    * Handles received signal.
    *
+   * May skip signal processing. In this case a `false` value should be returned. The next receiver in processing chain
+   * will receive the signal then.
+   *
    * @param signal - Received signal data packet.
    * @param channel - Communication channel the signal received from.
+   *
+   * @returns Either `true` if the signal processed, or `false` otherwise.
    */
-  receive(signal: TSignal, channel: CommChannel): void;
+  receive(signal: TSignal, channel: CommChannel): boolean;
 
 }
 
@@ -51,11 +59,14 @@ export interface CommResponder<TRequest extends CommPacket = CommPacket, TRespon
   /**
    * Responds to request received.
    *
+   * May skip request processing. In this case a `false`, `null`, or `undefined` value should be returned. The next
+   * responder in processing chain will receive the request then.
+   *
    * @param request - Received request data packet.
    * @param channel - Communication channel the request received from.
    *
-   * @returns `OnEvent` sender of response data packets.
+   * @returns Either `OnEvent` sender of response data packets, or falsy value if the request can not be responded.
    */
-  respond(request: TRequest, channel: CommChannel): OnEvent<[TResponse]>;
+  respond(request: TRequest, channel: CommChannel): OnEvent<[TResponse]> | false | null | undefined;
 
 }

--- a/src/communication/comm-processor.spec.ts
+++ b/src/communication/comm-processor.spec.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from '@jest/globals';
-import { CommProcessor } from './comm-processor';
+import { commProcessorBy } from './comm-processor';
+import { HandlerCommProcessor, NoopCommProcessor } from './handlers';
 
-describe('CommProcessor', () => {
-  describe('toString', () => {
-    it('provides string representation', () => {
-      expect(String(CommProcessor)).toBe('[CommProcessor]');
-    });
+describe('commProcessorBy', () => {
+  it('converts `undefined` to no-op processor', () => {
+    expect(commProcessorBy()).toBe(NoopCommProcessor);
+  });
+  it('does not convert processor', () => {
+
+    const processor = new HandlerCommProcessor();
+
+    expect(commProcessorBy(processor)).toBe(processor);
   });
 });

--- a/src/communication/comm-processor.ts
+++ b/src/communication/comm-processor.ts
@@ -18,22 +18,30 @@ export interface CommProcessor {
   /**
    * Handles received signal.
    *
+   * May skip signal processing. In this case a `false` value should be returned. The next receiver in processing chain
+   * will receive the signal then.
+   *
    * @param name - Received signal name.
    * @param signal - Received signal data packet.
    * @param channel - Communication channel the signal received from.
+   *
+   * @returns Either `true` if the signal processed, or `false` if unknown signal received.
    */
-  receive(name: string, signal: CommPacket, channel: CommChannel): void;
+  receive(name: string, signal: CommPacket, channel: CommChannel): boolean;
 
   /**
    * Responds to request received.
+   *
+   * May skip request processing. In this case a `false`, `null`, or `undefined` value should be returned. The next
+   * responder in processing chain will receive the request then.
    *
    * @param name - Received request name.
    * @param request - Received request data packet.
    * @param channel - Communication channel the request received from.
    *
-   * @returns `OnEvent` sender of response data packets.
+   * @returns Either `OnEvent` sender of response data packets, or falsy value if unknown request received.
    */
-  respond(name: string, request: CommPacket, channel: CommChannel): OnEvent<[CommPacket]>;
+  respond(name: string, request: CommPacket, channel: CommChannel): OnEvent<[CommPacket]> | false | null | undefined;
 
 }
 
@@ -45,7 +53,7 @@ export const CommProcessor: CxEntry<CommProcessor, CommHandler> = {
       UnitContext,
       (/*#__PURE__*/ cxDynamic({
         create(handlers: CommHandler[], _target: CxEntry.Target<CommProcessor, CommHandler>): CommProcessor {
-          return new HandlerCommProcessor(...handlers);
+          return new HandlerCommProcessor(...[...handlers].reverse());
         },
         assign({ get, to }) {
 

--- a/src/communication/comm-processor.ts
+++ b/src/communication/comm-processor.ts
@@ -1,14 +1,11 @@
-import { cxDynamic, CxEntry, cxScoped } from '@proc7ts/context-values';
 import { OnEvent } from '@proc7ts/fun-events';
-import { UnitContext } from '../unit';
-import { CommHandler } from './comm-handler';
+import { CommReceiver, CommResponder } from './comm-handler';
 import { CommPacket } from './comm-packet';
-import { HandlerCommProcessor, ProxyCommProcessor } from './handlers';
+import { HandlerCommProcessor, NoopCommProcessor } from './handlers';
+import { isCommProcessor } from './handlers/comm-handler.impl';
 
 /**
  * Inbound communication processor.
- *
- * Unit {@link Communicator} handles inbound commands with command processor provided for unit context.
  *
  * Can be constructed out of {@link CommHandler command handlers} as {@link HandlerCommProcessor}.
  */
@@ -43,22 +40,18 @@ export interface CommProcessor {
 }
 
 /**
- * Unit context entry containing inbound communication processor used by default.
+ * Converts inbound command handler to processor.
+ *
+ * @param handler - Handler to convert.
+ *
+ * @returns Communication processor.
  */
-export const CommProcessor: CxEntry<CommProcessor, CommHandler> = {
-  perContext: (/*#__PURE__*/ cxScoped(
-      UnitContext,
-      (/*#__PURE__*/ cxDynamic({
-        create(handlers: CommHandler[], _target: CxEntry.Target<CommProcessor, CommHandler>): CommProcessor {
-          return new HandlerCommProcessor(...[...handlers].reverse());
-        },
-        assign({ get, to }) {
-
-          const processor = new ProxyCommProcessor(get);
-
-          return receiver => to((_, by) => receiver(processor, by));
-        },
-      })),
-  )),
-  toString: () => '[CommProcessor]',
-};
+export function commProcessorBy(handler?: CommReceiver | CommResponder | CommProcessor): CommProcessor {
+  if (!handler) {
+    return NoopCommProcessor;
+  }
+  if (isCommProcessor(handler)) {
+    return handler;
+  }
+  return new HandlerCommProcessor(handler);
+}

--- a/src/communication/comm-processor.ts
+++ b/src/communication/comm-processor.ts
@@ -1,7 +1,6 @@
 import { cxDynamic, CxEntry, cxScoped } from '@proc7ts/context-values';
 import { OnEvent } from '@proc7ts/fun-events';
 import { UnitContext } from '../unit';
-import { CommChannel } from './comm-channel';
 import { CommHandler } from './comm-handler';
 import { CommPacket } from './comm-packet';
 import { HandlerCommProcessor, ProxyCommProcessor } from './handlers';
@@ -23,11 +22,10 @@ export interface CommProcessor {
    *
    * @param name - Received signal name.
    * @param signal - Received signal data packet.
-   * @param channel - Communication channel the signal received from.
    *
    * @returns Either `true` if the signal processed, or `false` if unknown signal received.
    */
-  receive(name: string, signal: CommPacket, channel: CommChannel): boolean;
+  receive(name: string, signal: CommPacket): boolean;
 
   /**
    * Responds to request received.
@@ -37,11 +35,10 @@ export interface CommProcessor {
    *
    * @param name - Received request name.
    * @param request - Received request data packet.
-   * @param channel - Communication channel the request received from.
    *
    * @returns Either `OnEvent` sender of response data packets, or falsy value if unknown request received.
    */
-  respond(name: string, request: CommPacket, channel: CommChannel): OnEvent<[CommPacket]> | false | null | undefined;
+  respond(name: string, request: CommPacket): OnEvent<[CommPacket]> | false | null | undefined;
 
 }
 

--- a/src/communication/comm-protocol.spec.ts
+++ b/src/communication/comm-protocol.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from '@jest/globals';
+import { CommProtocol } from './comm-protocol';
+
+describe('CommProtocol', () => {
+  describe('toString', () => {
+    it('provides string representation', () => {
+      expect(String(CommProtocol)).toBe('[CommProtocol]');
+    });
+  });
+});

--- a/src/communication/comm-protocol.ts
+++ b/src/communication/comm-protocol.ts
@@ -1,0 +1,47 @@
+import { cxDynamic, CxEntry, cxScoped } from '@proc7ts/context-values';
+import { Unit, UnitContext } from '../unit';
+import { CommHandler, CommReceiver, CommResponder } from './comm-handler';
+import { CommProcessor } from './comm-processor';
+import { HandlerCommProtocol, ProxyCommProtocol } from './handlers';
+
+/**
+ * Per-unit communication protocol for handling inbound commands.
+ *
+ * Unit's {@link Communicator} handles inbound commands with protocol provided in unit context.
+ *
+ * Can be constructed out of {@link CommHandler command handlers} as {@link HandlerCommProtocol}.
+ */
+export interface CommProtocol {
+
+  /**
+   * Builds communication processor for commands inbound from the `source` unit.
+   *
+   * @param source - A unit to process inbound events from.
+   *
+   * @returns Either inbound signals receiver, request resolver, communication processor, or `undefined` if no inbound
+   * commands expected.
+   */
+  channelProcessor(source: Unit): CommReceiver | CommResponder | CommProcessor | undefined;
+
+}
+
+/**
+ * Unit context entry containing communication protocol used by default.
+ */
+export const CommProtocol: CxEntry<CommProtocol, CommHandler> = {
+  perContext: (/*#__PURE__*/ cxScoped(
+      UnitContext,
+      (/*#__PURE__*/ cxDynamic({
+        create(handlers: CommHandler[], _target: CxEntry.Target<CommProtocol, CommHandler>): CommProtocol {
+          return new HandlerCommProtocol(...[...handlers].reverse());
+        },
+        assign({ get, to }) {
+
+          const processor = new ProxyCommProtocol(get);
+
+          return receiver => to((_, by) => receiver(processor, by));
+        },
+      })),
+  )),
+  toString: () => '[CommProtocol]',
+};

--- a/src/communication/handlers/comm-handler.impl.ts
+++ b/src/communication/handlers/comm-handler.impl.ts
@@ -1,0 +1,10 @@
+import { CommHandler, CommReceiver, CommResponder } from '../comm-handler';
+import { CommProcessor } from '../comm-processor';
+
+export function isCommProcessor(handler: CommHandler): handler is CommProcessor {
+  return typeof (handler as Partial<CommReceiver>).name === 'undefined';
+}
+
+export function isCommResponder(handler: CommHandler): handler is CommResponder {
+  return typeof (handler as Partial<CommResponder>).respond === 'function';
+}

--- a/src/communication/handlers/final.comm-processor.ts
+++ b/src/communication/handlers/final.comm-processor.ts
@@ -1,0 +1,62 @@
+import { OnEvent, onEventBy } from '@proc7ts/fun-events';
+import { CommChannel } from '../comm-channel';
+import { CommError } from '../comm-error';
+import { CommPacket } from '../comm-packet';
+import { CommProcessor } from '../comm-processor';
+
+/**
+ * Inbound communication processor, final in processing chain.
+ *
+ * Its methods raise errors if is not able to process a command.
+ */
+export class FinalCommProcessor implements CommProcessor {
+
+  readonly #processor: CommProcessor;
+
+  /**
+   * Constructs final communication processor.
+   *
+   * @param processor - Processor to handle inbound commands by.
+   */
+  constructor(processor: CommProcessor) {
+    this.#processor = processor;
+  }
+
+  /**
+   * Handles received signal.
+   *
+   * Never skips signal processing
+   *
+   * @param name - Received signal name.
+   * @param signal - Received signal data packet.
+   * @param channel - Communication channel the signal received from.
+   *
+   * @returns Either `true`.
+   * @throws CommError  If unknown signal received.
+   */
+  receive(name: string, signal: CommPacket, channel: CommChannel): true {
+    if (!this.#processor.receive(name, signal, channel)) {
+      throw new CommError(channel.to, `Unknown signal received: "${name}"`);
+    }
+    return true;
+  }
+
+  /**
+   * Responds to request received.
+   *
+   * Never skips request processing.
+   *
+   * @param name - Received request name.
+   * @param request - Received request data packet.
+   * @param channel - Communication channel the request received from.
+   *
+   * @returns `OnEvent` sender of response data packets. If unknown request received, the response supply wil be cut off
+   * with `CommError` as its reason.
+   */
+  respond(name: string, request: CommPacket, channel: CommChannel): OnEvent<[CommPacket]> {
+    return this.#processor.respond(name, request, channel) || onEventBy(({ supply }) => {
+      supply.off(new CommError(channel.to, `Unknown request received: "${name}"`));
+    });
+  }
+
+}

--- a/src/communication/handlers/final.comm-processor.ts
+++ b/src/communication/handlers/final.comm-processor.ts
@@ -1,6 +1,4 @@
 import { OnEvent, onEventBy } from '@proc7ts/fun-events';
-import { CommChannel } from '../comm-channel';
-import { CommError } from '../comm-error';
 import { CommPacket } from '../comm-packet';
 import { CommProcessor } from '../comm-processor';
 
@@ -29,14 +27,13 @@ export class FinalCommProcessor implements CommProcessor {
    *
    * @param name - Received signal name.
    * @param signal - Received signal data packet.
-   * @param channel - Communication channel the signal received from.
    *
    * @returns Either `true`.
-   * @throws CommError  If unknown signal received.
+   * @throws TypeError  If unknown signal received.
    */
-  receive(name: string, signal: CommPacket, channel: CommChannel): true {
-    if (!this.#processor.receive(name, signal, channel)) {
-      throw new CommError(channel.to, `Unknown signal received: "${name}"`);
+  receive(name: string, signal: CommPacket): true {
+    if (!this.#processor.receive(name, signal)) {
+      throw new TypeError(`Unknown signal received: "${name}"`);
     }
     return true;
   }
@@ -48,14 +45,13 @@ export class FinalCommProcessor implements CommProcessor {
    *
    * @param name - Received request name.
    * @param request - Received request data packet.
-   * @param channel - Communication channel the request received from.
    *
    * @returns `OnEvent` sender of response data packets. If unknown request received, the response supply wil be cut off
-   * with `CommError` as its reason.
+   * with `TypeError` as its reason.
    */
-  respond(name: string, request: CommPacket, channel: CommChannel): OnEvent<[CommPacket]> {
-    return this.#processor.respond(name, request, channel) || onEventBy(({ supply }) => {
-      supply.off(new CommError(channel.to, `Unknown request received: "${name}"`));
+  respond(name: string, request: CommPacket): OnEvent<[CommPacket]> {
+    return this.#processor.respond(name, request) || onEventBy(({ supply }) => {
+      supply.off(new TypeError(`Unknown request received: "${name}"`));
     });
   }
 

--- a/src/communication/handlers/handler.comm-processor.ts
+++ b/src/communication/handlers/handler.comm-processor.ts
@@ -1,5 +1,4 @@
 import { OnEvent } from '@proc7ts/fun-events';
-import { CommChannel } from '../comm-channel';
 import { CommHandler, CommReceiver } from '../comm-handler';
 import { CommPacket } from '../comm-packet';
 import { CommProcessor } from '../comm-processor';
@@ -23,9 +22,9 @@ export class HandlerCommProcessor implements CommProcessor {
       if (isCommProcessor(handler)) {
         this.#addProcessor(handler);
       } else if (isCommReceiver(handler)) {
-        this.#receiversOf(handler.name).push((_name, signal, channel) => handler.receive(signal, channel));
+        this.#receiversOf(handler.name).push((_name, signal) => handler.receive(signal));
       } else {
-        this.#respondersOf(handler.name).push((_name, request, channel) => handler.respond(request, channel));
+        this.#respondersOf(handler.name).push((_name, request) => handler.respond(request));
       }
     }
   }
@@ -64,16 +63,16 @@ export class HandlerCommProcessor implements CommProcessor {
     return responders;
   }
 
-  receive(name: string, signal: CommPacket, channel: CommChannel): boolean {
-    return this.#receiversOf(name).some(receiver => receiver(name, signal, channel));
+  receive(name: string, signal: CommPacket): boolean {
+    return this.#receiversOf(name).some(receiver => receiver(name, signal));
   }
 
-  respond(name: string, request: CommPacket, channel: CommChannel): OnEvent<[CommPacket]> | false | null | undefined {
+  respond(name: string, request: CommPacket): OnEvent<[CommPacket]> | false | null | undefined {
 
     let response: OnEvent<[CommPacket]> | false | null | undefined;
 
     for (const responder of this.#respondersOf(name)) {
-      response = responder(name, request, channel);
+      response = responder(name, request);
       if (response) {
         break;
       }

--- a/src/communication/handlers/handler.comm-protocol.ts
+++ b/src/communication/handlers/handler.comm-protocol.ts
@@ -1,0 +1,47 @@
+import { isPresent } from '@proc7ts/primitives';
+import { Unit } from '../../unit';
+import { CommHandler, CommReceiver, CommResponder } from '../comm-handler';
+import { CommProcessor } from '../comm-processor';
+import { CommProtocol } from '../comm-protocol';
+import { HandlerCommProcessor } from './handler.comm-processor';
+
+/**
+ * Communication protocol that handles inbound commands with matching handlers.
+ */
+export class HandlerCommProtocol implements CommProtocol {
+
+  readonly #handlers: CommHandler[];
+
+  /**
+   * Constructs handler communication protocol.
+   *
+   * @param handlers - Communication handlers to process inbound commands with.
+   */
+  constructor(...handlers: CommHandler[]) {
+    this.#handlers = handlers;
+  }
+
+  channelProcessor(source: Unit): CommReceiver | CommResponder | CommProcessor | undefined {
+
+    const handlers = this.#handlers.map(handler => CommProcessor$forUnit(source, handler))
+        .filter<CommReceiver | CommResponder | CommProcessor>(isPresent);
+
+    return handlers.length
+        ? (handlers.length > 1
+            ? new HandlerCommProcessor(...handlers)
+            : handlers[0])
+        : undefined;
+  }
+
+}
+
+function isCommProtocol(handler: CommHandler): handler is CommProtocol {
+  return typeof (handler as Partial<CommProtocol>).channelProcessor === 'function';
+}
+
+function CommProcessor$forUnit(
+    source: Unit,
+    handler: CommHandler,
+): CommReceiver | CommResponder | CommProcessor | undefined {
+  return isCommProtocol(handler) ? handler.channelProcessor(source) : handler;
+}

--- a/src/communication/handlers/index.ts
+++ b/src/communication/handlers/index.ts
@@ -1,3 +1,6 @@
 export * from './final.comm-processor';
 export * from './handler.comm-processor';
+export * from './handler.comm-protocol';
+export * from './noop.comm-processor';
 export * from './proxy.comm-processor';
+export * from './proxy.comm-protocol';

--- a/src/communication/handlers/index.ts
+++ b/src/communication/handlers/index.ts
@@ -1,2 +1,3 @@
+export * from './final.comm-processor';
 export * from './handler.comm-processor';
 export * from './proxy.comm-processor';

--- a/src/communication/handlers/noop-comm-processor.ts
+++ b/src/communication/handlers/noop-comm-processor.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals';
+import { NoopCommProcessor } from './noop.comm-processor';
+
+describe('noopCommProcessor', () => {
+  describe('receive', () => {
+    it('does not process signals', () => {
+      expect(NoopCommProcessor.receive(null!, null!)).toBe(false);
+      expect(new NoopCommProcessor().receive(null!, null!)).toBe(false);
+    });
+  });
+  describe('respond', () => {
+    it('does not respond', () => {
+      expect(NoopCommProcessor.respond(null!, null!)).toBeUndefined();
+      expect(new NoopCommProcessor().respond(null!, null!)).toBeUndefined();
+    });
+  });
+});

--- a/src/communication/handlers/noop.comm-processor.ts
+++ b/src/communication/handlers/noop.comm-processor.ts
@@ -1,0 +1,25 @@
+import { CommPacket } from '../comm-packet';
+import { CommProcessor } from '../comm-processor';
+
+/**
+ * Communication processor that never processes inbound commands.
+ */
+export class NoopCommProcessor implements CommProcessor {
+
+  static receive(_name: string, _signal: CommPacket): false {
+    return false;
+  }
+
+  static respond(_name: string, _request: CommPacket): undefined {
+    return;
+  }
+
+  receive(_name: string, _signal: CommPacket): false {
+    return false;
+  }
+
+  respond(_name: string, _request: CommPacket): undefined {
+    return;
+  }
+
+}

--- a/src/communication/handlers/proxy.comm-processor.ts
+++ b/src/communication/handlers/proxy.comm-processor.ts
@@ -20,11 +20,11 @@ export class ProxyCommProcessor implements CommProcessor {
     this.#get = getProcessor;
   }
 
-  receive(name: string, signal: CommPacket, channel: CommChannel): void {
-    this.#get().receive(name, signal, channel);
+  receive(name: string, signal: CommPacket, channel: CommChannel): boolean {
+    return this.#get().receive(name, signal, channel);
   }
 
-  respond(name: string, request: CommPacket, channel: CommChannel): OnEvent<[CommPacket]> {
+  respond(name: string, request: CommPacket, channel: CommChannel): OnEvent<[CommPacket]> | false | null | undefined {
     return this.#get().respond(name, request, channel);
   }
 

--- a/src/communication/handlers/proxy.comm-processor.ts
+++ b/src/communication/handlers/proxy.comm-processor.ts
@@ -1,5 +1,4 @@
 import { OnEvent } from '@proc7ts/fun-events';
-import { CommChannel } from '../comm-channel';
 import { CommPacket } from '../comm-packet';
 import { CommProcessor } from '../comm-processor';
 
@@ -20,12 +19,12 @@ export class ProxyCommProcessor implements CommProcessor {
     this.#get = getProcessor;
   }
 
-  receive(name: string, signal: CommPacket, channel: CommChannel): boolean {
-    return this.#get().receive(name, signal, channel);
+  receive(name: string, signal: CommPacket): boolean {
+    return this.#get().receive(name, signal);
   }
 
-  respond(name: string, request: CommPacket, channel: CommChannel): OnEvent<[CommPacket]> | false | null | undefined {
-    return this.#get().respond(name, request, channel);
+  respond(name: string, request: CommPacket): OnEvent<[CommPacket]> | false | null | undefined {
+    return this.#get().respond(name, request);
   }
 
 }

--- a/src/communication/handlers/proxy.comm-protocol.ts
+++ b/src/communication/handlers/proxy.comm-protocol.ts
@@ -1,0 +1,26 @@
+import { Unit } from '../../unit';
+import { CommReceiver, CommResponder } from '../comm-handler';
+import { CommProcessor } from '../comm-processor';
+import { CommProtocol } from '../comm-protocol';
+
+/**
+ * Inbound communication protocol that proxies commands to another one.
+ */
+export class ProxyCommProtocol implements CommProtocol {
+
+  readonly #get: (this: void) => CommProtocol;
+
+  /**
+   * Constructs proxy communication protocol.
+   *
+   * @param getProtocol - Returns communication protocol to proxy inbound commands to.
+   */
+  constructor(getProtocol: (this: void) => CommProtocol) {
+    this.#get = getProtocol;
+  }
+
+  channelProcessor(source: Unit): CommReceiver | CommResponder | CommProcessor | undefined {
+    return this.#get().channelProcessor(source);
+  }
+
+}

--- a/src/communication/index.ts
+++ b/src/communication/index.ts
@@ -5,6 +5,7 @@ export * from './comm-channel';
 export * from './comm-error';
 export * from './comm-handler';
 export * from './comm-packet';
+export * from './comm-protocol';
 export * from './comm-processor';
 export * from './communicator';
 export * from './handlers';

--- a/src/hub/formation-manager.spec.ts
+++ b/src/hub/formation-manager.spec.ts
@@ -4,7 +4,7 @@ import { onEventBy, onPromise } from '@proc7ts/fun-events';
 import { Logger } from '@proc7ts/logger';
 import { Supply } from '@proc7ts/supply';
 import { MessageChannel } from 'worker_threads';
-import { CommPacket, CommProcessor, CommResponder, MessageCommChannel } from '../communication';
+import { CommPacket, CommProtocol, CommResponder, MessageCommChannel } from '../communication';
 import { Formation, FormationContext } from '../formation';
 import { Formation$createAssets } from '../impl/formation';
 import { Hub$createAssets } from '../impl/hub';
@@ -130,7 +130,7 @@ describe('FormationManager', () => {
             },
           };
 
-          fmnTest.formationBuilder.provide(cxConstAsset(CommProcessor, responder));
+          fmnTest.formationBuilder.provide(cxConstAsset(CommProtocol, responder));
         });
 
         const ctl = formationManager.formationCtl(testFmn);

--- a/src/impl/formation/formation.ctl-channel.ts
+++ b/src/impl/formation/formation.ctl-channel.ts
@@ -1,7 +1,13 @@
 import { CxEntry, cxScoped, cxSingle } from '@proc7ts/context-values';
 import { Logger } from '@proc7ts/logger';
 import { lazyValue } from '@proc7ts/primitives';
-import { CommChannel, CommProcessor, MessageCommChannel, ProxyCommProcessor } from '../../communication';
+import {
+  CommChannel,
+  commProcessorBy,
+  CommProtocol,
+  MessageCommChannel,
+  ProxyCommProcessor,
+} from '../../communication';
 import { FormationContext } from '../../formation';
 import { Formation$LaunchData } from '../formation.launch-data';
 
@@ -14,13 +20,16 @@ export const Formation$CtlChannel: CxEntry<Formation$CtlChannel> = {
         byDefault: target => {
 
           const context = target.get(FormationContext);
+          const { hub: to } = context;
           const launchData = target.get(Formation$LaunchData);
 
           return new MessageCommChannel({
-            to: context.hub,
+            to,
             port: launchData.hubPort,
             logger: target.get(Logger),
-            processor: new ProxyCommProcessor(lazyValue(() => target.get(CommProcessor))),
+            processor: new ProxyCommProcessor(lazyValue(
+                () => commProcessorBy(target.get(CommProtocol).channelProcessor(to)),
+            )),
           });
         },
       }),

--- a/src/impl/hub/hub.comm-linker.ts
+++ b/src/impl/hub/hub.comm-linker.ts
@@ -7,7 +7,8 @@ import {
   CommChannel,
   CommLink,
   CommLinker,
-  CommProcessor,
+  commProcessorBy,
+  CommProtocol,
   MessageCommChannel,
   ProxyCommChannel,
 } from '../../communication';
@@ -34,7 +35,7 @@ export class Hub$CommLinker implements CommLinker {
 
     target.provide(cxConstAsset(CommLinker, linker));
     target.provide(cxConstAsset(
-        CommProcessor,
+        CommProtocol,
         {
           name: LinkMessagePortCommRequest,
           respond: (request: LinkMessagePortCommRequest) => linker.#link(request),
@@ -128,7 +129,7 @@ class Hub$CommLink implements CommLink {
           mapOn_(() => new MessageCommChannel({
             to,
             port: port1,
-            processor: this.#context.get(CommProcessor),
+            processor: commProcessorBy(this.#context.get(CommProtocol).channelProcessor(to)),
             logger,
           })),
       ),

--- a/src/impl/hub/hub.formation-manager.ts
+++ b/src/impl/hub/hub.formation-manager.ts
@@ -2,7 +2,7 @@ import { CxAsset, CxEntry } from '@proc7ts/context-values';
 import { trackValue } from '@proc7ts/fun-events';
 import { Logger } from '@proc7ts/logger';
 import { lazyValue } from '@proc7ts/primitives';
-import { CommChannel, CommProcessor, ProxyCommChannel, ProxyCommProcessor } from '../../communication';
+import { CommChannel, commProcessorBy, CommProtocol, ProxyCommChannel, ProxyCommProcessor } from '../../communication';
 import { Formation, FormationContext } from '../../formation';
 import { FormationCtl, FormationManager, FormationStarter } from '../../hub';
 
@@ -62,7 +62,9 @@ class Hub$FormationCtl implements FormationCtl {
 
       const starter = this.#context.get(FormationStarter);
       const target = trackValue<CommChannel>();
-      const processor = new ProxyCommProcessor(lazyValue(() => this.#context.get(CommProcessor)));
+      const processor = new ProxyCommProcessor(lazyValue(
+          () => commProcessorBy(this.#context.get(CommProtocol).channelProcessor(this.#formation)),
+      ));
 
       this.#channel = new ProxyCommChannel({
         to: this.formation,

--- a/src/impl/hub/hub.unit-locator.ts
+++ b/src/impl/hub/hub.unit-locator.ts
@@ -1,7 +1,7 @@
 import { cxConstAsset } from '@proc7ts/context-builder';
 import { CxEntry } from '@proc7ts/context-values';
 import { afterThe, OnEvent, onEventBy } from '@proc7ts/fun-events';
-import { CommProcessor } from '../../communication';
+import { CommProtocol } from '../../communication';
 import { Formation, UnitLocation, UnitLocator } from '../../formation';
 import { OrderUnits, Unit } from '../../unit';
 import { Formation$Host } from '../formation.host';
@@ -19,7 +19,7 @@ export class Hub$UnitLocator implements UnitLocator {
 
     target.provide(cxConstAsset(UnitLocator, locator));
     target.provide(cxConstAsset(
-        CommProcessor,
+        CommProtocol,
         {
           name: UnitLocationCommRequest,
           respond: (request: UnitLocationCommRequest) => locator.#locateUnit(request),


### PR DESCRIPTION
- `CommHandler` is no longer generic
- `CommHandler` may skip command processing
- Support `CommProcessor` as `CommHandler`
- Do not pass channel instance to command handlers
- Introduce `CommProtocol` - per-unit communication protocol
